### PR TITLE
Add queries and presets fro AWS CloudFront

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,13 +11,12 @@
   - [Help output](#help-output)
   - [Environment Variables](#environment-variables)
   - [Basic Usage](#basic-usage)
-  - [Important Commandline Arguments](#important-commendline-arguments)
-  - [Presets](#presets)
+  - [Important Commandline Arguments](#important-commandline-arguments)
+  - [AWS CloudWatch Metrics Presets](#aws-cloudwatch-metrics-presets)
   - [Custom Presets](#custom-presets)
   - [Exporting Preset Configuration](#exporting-preset-configuration)
 
 - [Configuration](#configuration)
-  - [AWS credentials](#AWS-credentials)
   - [Asset registration](#asset-registration)
   - [Check definition](#check-definition)
 - [Installation from source](#installation-from-source)
@@ -66,18 +65,18 @@ Flags:
 
 ### Environment Variables
 
-|Argument                       |Environment Variable                 |
-|-------------------------------|-------------------------------------|
-|--region                       |AWS_REGION                           |
-|--profile                      |AWS_PROFILE                          |
-|--namespace                    | CLOUDWATCH_CHECK_NAMESPACE          |
-|--metric-filter                | CLOUDWATCH_CHECK_METRIC_FILTER      | 
-|--dimension-filters            | CLOUDWATCH_CHECK_DIMENSION_FILTERS  |
-|--stats                        | CLOUDWATCH_CHECK_STATS              |
-|--config                       | CLOUDWATCH_CHECK_CONFIG             |
-|--preset                       | CLOUDWATCH_CHECK_PRESET             |
-|--max-pages                    | CLOUDWATCH_CHECK_MAX_PAGES          |
-|--period-minutes               | CLOUDWATCH_CHECK_PERIOD_MINUTES     |
+| Argument            | Environment Variable               |
+|---------------------|------------------------------------|
+| --region            | AWS_REGION                         |
+| --profile           | AWS_PROFILE                        |
+| --namespace         | CLOUDWATCH_CHECK_NAMESPACE         |
+| --metric-filter     | CLOUDWATCH_CHECK_METRIC_FILTER     | 
+| --dimension-filters | CLOUDWATCH_CHECK_DIMENSION_FILTERS |
+| --stats             | CLOUDWATCH_CHECK_STATS             |
+| --config            | CLOUDWATCH_CHECK_CONFIG            |
+| --preset            | CLOUDWATCH_CHECK_PRESET            |
+| --max-pages         | CLOUDWATCH_CHECK_MAX_PAGES         |
+| --period-minutes    | CLOUDWATCH_CHECK_PERIOD_MINUTES    |
 
   
 ### Basic Usage
@@ -125,12 +124,12 @@ This check comes with several presets for specific AWS Services.  These presets 
 
 The list of existing service presets includes:
 
-| Preset Name      |Description                 |
-|------------------|----------------------------|
-| ALB              | Preset Metrics for AWS Application Load Balancer            |
-| CLB              | Preset Metrics for AWS Classic Load Balancer                |
-| EC2              | Preset Metrics for AWS EC2                                  |
-| CloudFront       | Preset Metrics for AWS CloudFront. Note: requires --region us-east-1 |
+| Preset Name | Description                                                          |
+|-------------|----------------------------------------------------------------------|
+| ALB         | Preset Metrics for AWS Application Load Balancer                     |
+| CLB         | Preset Metrics for AWS Classic Load Balancer                         |
+| EC2         | Preset Metrics for AWS EC2                                           |
+| CloudFront  | Preset Metrics for AWS CloudFront. Note: requires --region us-east-1 |
 
 *Note:* The --dimension-filters and --metric-filter arguments can be used to further narrow the results
 from the service presets.
@@ -144,7 +143,8 @@ or `CLOUDWATCH_CHECK_CONFIG` envvar.
 ### Exporting Preset Configuration
 
 The `--output-config` option can be used to generate the json representation of a metric query. 
-This json can be editted as needed to customize the metric query. 
+This json can be edited as needed to customize the metric query. 
+
 #### Export examples 
 
 Output a simple `AWS/EC2` namespace metrics configuration
@@ -161,7 +161,6 @@ Output the EC2 preset configuration
 ```
 sensu-cloudwatch-check -P "EC2" --region "us-east-1" --output-config
 ```
-
 
 ## Configuration
 

--- a/common/common.go
+++ b/common/common.go
@@ -34,7 +34,7 @@ func BuildLabelBase(m types.Metric) string {
 }
 
 func DimString(dims []types.Dimension) string {
-	dimStrings := []string{}
+	dimStrings := make([]string, 0, len(dims))
 	if len(dims) > 0 {
 		for _, d := range dims {
 			dimStrings = append(dimStrings, fmt.Sprintf(`%v="%v"`, *d.Name, *d.Value))
@@ -45,11 +45,11 @@ func DimString(dims []types.Dimension) string {
 }
 
 func BuildDimensionFilters(input []string) ([]types.DimensionFilter, error) {
-	output := []types.DimensionFilter{}
+	output := make([]types.DimensionFilter, 0, len(input))
 	for _, item := range input {
 		segments := strings.Split(strings.TrimSpace(item), "=")
 		if len(segments) < 1 || len(segments) > 2 {
-			return nil, fmt.Errorf("Error parsing dimension filters")
+			return nil, fmt.Errorf("error parsing dimension filters")
 		}
 		filter := types.DimensionFilter{Name: &segments[0]}
 		if len(segments) > 1 {
@@ -63,7 +63,7 @@ func BuildDimensionFilters(input []string) ([]types.DimensionFilter, error) {
 func RemoveDuplicateStrings(elements []string) []string {
 	// Use map to record duplicates as we find them.
 	encountered := map[string]bool{}
-	result := []string{}
+	result := make([]string, 0)
 
 	for v := range elements {
 		if encountered[elements[v]] {

--- a/presets/alb.go
+++ b/presets/alb.go
@@ -6,7 +6,7 @@ type ALB struct {
 	Preset
 }
 
-// Overwrite the Preset Ready function to enforce specific behavior
+// Ready overwrites the Preset Ready function to enforce specific behavior
 func (p *ALB) Ready() error {
 	if p.verbose {
 		fmt.Println("ALB::Ready Setting up presets")

--- a/presets/cloudfront.go
+++ b/presets/cloudfront.go
@@ -6,7 +6,7 @@ type CloudFront struct {
 	Preset
 }
 
-// Overwrite the Preset Ready function to enforce specific behavior
+// Ready overwrites the Preset Ready function to enforce specific behavior
 func (p *CloudFront) Ready() error {
 	if p.verbose {
 		fmt.Println("CloudFront::Ready Setting up presets")

--- a/presets/none.go
+++ b/presets/none.go
@@ -120,7 +120,7 @@ func (p *None) BuildMetricDataQueries(period int32) ([]types.MetricDataQuery, er
 		for j := range p.Stats {
 			id := uuid.New()
 			idString := "aws_" + strings.ReplaceAll(id.String(), "-", "_")
-			labelString := fmt.Sprintf("%v.%v", common.BuildLabelBase(p.Metrics[i]), common.ToSnakeCase(p.Stats[j]))
+			labelString := fmt.Sprintf("%v_%v", common.BuildLabelBase(p.Metrics[i]), common.ToSnakeCase(p.Stats[j]))
 			dataQuery := types.MetricDataQuery{
 				Id:    &idString,
 				Label: &labelString,


### PR DESCRIPTION
* Modify output to respect the Prometheus preferred format by replacing the `.` with a `_` in the metric name
* Modify help and metric type lines to remove the trailing statistic (ex. aws_xxx.average becomes aws_xxx)

New output looks like this:
```
# HELP aws_cloud_front_requests Namespace:AWS/CloudFront MetricName:Requests Region:us-east-1
# TYPE aws_cloud_front_requests gauge
aws_cloud_front_requests_average{Region="Global",DistributionId="EZ2HSBO4PG1GF"} 1 1645819380000
aws_cloud_front_requests_sum{Region="Global",DistributionId="EZ2HSBO4PG1GF"} 1 1645819380000
aws_cloud_front_requests_sample_count{Region="Global",DistributionId="EZ2HSBO4PG1GF"} 1 1645819380000
aws_cloud_front_requests_maximum{Region="Global",DistributionId="EZ2HSBO4PG1GF"} 1 1645819380000
aws_cloud_front_requests_minimum{Region="Global",DistributionId="EZ2HSBO4PG1GF"} 1 1645819380000
```

instead of this:
```
# HELP aws_cloud_front_requests.average Namespace:AWS/CloudFront MetricName:Requests Region:us-east-1
# TYPE aws_cloud_front_requests.average gauge
aws_cloud_front_requests.average{Region="Global",DistributionId="EZ2HSBO4PG1GF"} 4.5 1645021140000
aws_cloud_front_requests.sum{Region="Global",DistributionId="EZ2HSBO4PG1GF"} 18 1645021140000
aws_cloud_front_requests.sample_count{Region="Global",DistributionId="EZ2HSBO4PG1GF"} 4 1645021140000
aws_cloud_front_requests.maximum{Region="Global",DistributionId="EZ2HSBO4PG1GF"} 9 1645021140000
aws_cloud_front_requests.minimum{Region="Global",DistributionId="EZ2HSBO4PG1GF"} 1 1645021140000
```

I tested that the metrics exposed when the pay option is enabled are present.