### PR TITLE
fix error on missing metric in preset configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+- Fixed preset metrics handling for situation where requests metrics does not include All service metrics
+- Add new option to enable error return status if service metrics are missing from requested metric list.  Useful for development of new presets or CI testing to catch when AWS extends a metrics set. 
+
 ## [0.0.1] - 2000-01-01
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Flags:
       --profile string              AWS Credential Profile (for security use envvar AWS_PROFILE)
   -c, --config string               Use measurement configuration JSON string
   -N, --namespace string            Cloudwatch Metric Namespace
-  -D, --dimension-filters strings    Comma separated list of AWS Cloudwatch Dimension Filters Ex: "Name, SecondName=SecondValue"
+  -D, --dimension-filters strings   Comma separated list of AWS Cloudwatch Dimension Filters Ex: "Name, SecondName=SecondValue"
   -M, --metric string               Cloudwatch Metric Name
   -S, --stats strings               Comma separated list of AWS Cloudwatch Status Ex: "Average, Sum" (default [Average,Sum,SampleCount,Maximum,Minimum])
   -m, --max-pages int               Maximum number of result pages. A zero value will disable the limit (default 1)
@@ -58,6 +58,7 @@ Flags:
       --recently-active             Only include metrics recently active in aprox last 3 hours
       --region string               AWS Region to use, (or set envvar AWS_REGION)
   -v, --verbose                     Enable verbose output
+      --error-on-missing            Error if requested metrics configuration is missing a known metric from the AWS service metric list
   -n, --dry-run                     Dryrun only list metrics, do not get metrics data
   -h, --help                        help for sensu-cloudwatch-check
 
@@ -77,7 +78,7 @@ Flags:
 | --preset            | CLOUDWATCH_CHECK_PRESET            |
 | --max-pages         | CLOUDWATCH_CHECK_MAX_PAGES         |
 | --period-minutes    | CLOUDWATCH_CHECK_PERIOD_MINUTES    |
-
+| --error-on-missing  | CLOUDWATCH_CHECK_ERROR_ON_MISSING  |
   
 ### Basic Usage
 To retrieve all available metrics from a specific AWS service from a particular region is to specific the 

--- a/main.go
+++ b/main.go
@@ -34,6 +34,7 @@ type Config struct {
 	DimensionFilterStrings []string
 	DimensionFilters       []types.DimensionFilter
 	Verbose                bool
+	ErrorOnMissing         bool
 	DryRun                 bool
 	RecentlyActive         bool
 	MaxPages               int
@@ -182,6 +183,14 @@ var (
 			Default:   false,
 			Usage:     "Enable verbose output",
 			Value:     &plugin.Verbose,
+		}, {
+			Path:      "error-on-missing",
+			Argument:  "error-on-missing",
+			Shorthand: "",
+			Default:   false,
+			Env:       "CLOUDWATCH_CHECK_ERROR_ON_MISSING",
+			Usage:     "Error if requested metrics configuration is missing a known metric from the AWS service metric list",
+			Value:     &plugin.ErrorOnMissing,
 		}, {
 			Path:      "dry-run",
 			Argument:  "dry-run",
@@ -536,6 +545,11 @@ func checkFunction(client ServiceAPI) (int, error) {
 	err = plugin.Preset.SetVerbose(plugin.Verbose)
 	if err != nil {
 		fmt.Println("Preset SetVerbose error")
+		return sensu.CheckStateCritical, nil
+	}
+	err = plugin.Preset.SetErrorOnMissing(plugin.ErrorOnMissing)
+	if err != nil {
+		fmt.Println("Preset SetErrorOnMissing error")
 		return sensu.CheckStateCritical, nil
 	}
 	err = plugin.Preset.Ready()

--- a/presets/alb_test.go
+++ b/presets/alb_test.go
@@ -31,6 +31,8 @@ func TestALBAddMetrics(t *testing.T) {
 	elb := &ALB{}
 	err := elb.SetVerbose(true)
 	assert.NoError(err)
+        err = elb.SetErrorOnMissing(true)
+        assert.NoError(err)
 	err = elb.Ready()
 	assert.NoError(err)
 	metricNames := []string{

--- a/presets/clb_test.go
+++ b/presets/clb_test.go
@@ -31,6 +31,8 @@ func TestCLBAddMetrics(t *testing.T) {
 	preset := &CLB{}
 	err := preset.SetVerbose(true)
 	assert.NoError(err)
+        err = preset.SetErrorOnMissing(true)
+        assert.NoError(err)
 	err = preset.Ready()
 	assert.NoError(err)
 	metricNames := []string{

--- a/presets/cloudfront_test.go
+++ b/presets/cloudfront_test.go
@@ -31,6 +31,8 @@ func TestCloudFrontAddMetrics(t *testing.T) {
 	preset := &CloudFront{}
 	err := preset.SetVerbose(true)
 	assert.NoError(err)
+        err = preset.SetErrorOnMissing(true)
+        assert.NoError(err)
 	err = preset.Ready()
 	assert.NoError(err)
 	metricNames := []string{

--- a/presets/common.go
+++ b/presets/common.go
@@ -35,6 +35,7 @@ type Preset struct {
 	configMap         map[string][]StatConfig
 	measurementString string
 	verbose           bool
+	errorOnMissing    bool
 }
 
 type PresetInterface interface {
@@ -49,6 +50,7 @@ type PresetInterface interface {
 	GetRegion() string
 	SetRegion(region string) error
 	SetVerbose(flag bool) error
+	SetErrorOnMissing(flag bool) error
 	SetMeasurementString(config string) error
 	BuildMeasurementConfig() error
 	GetMeasurementString(pretty bool) (string, error)
@@ -195,6 +197,11 @@ func (p *Preset) SetVerbose(flag bool) error {
 	return nil
 }
 
+func (p *Preset) SetErrorOnMissing(flag bool) error {
+	p.errorOnMissing = flag
+	return nil
+}
+
 func (p *Preset) SetMeasurementString(config string) error {
 	p.measurementString = config
 	return nil
@@ -250,7 +257,9 @@ func (p *Preset) AddMetrics(metrics []types.Metric) error {
 			if p.verbose {
 				fmt.Println(str)
 			}
-			errStrings = append(errStrings, str)
+                        if p.errorOnMissing {
+			   errStrings = append(errStrings, str)
+                        }
 		}
 	}
 	if len(errStrings) > 0 {

--- a/presets/ec2_test.go
+++ b/presets/ec2_test.go
@@ -36,6 +36,8 @@ func TestEC2AddMetrics(t *testing.T) {
 	metricNames := []string{
 		"test",
 	}
+	err = preset.SetErrorOnMissing(true)
+	assert.NoError(err)
 	metrics := []types.Metric{}
 	namespace := "AWS/EC2"
 	for i := range metricNames {


### PR DESCRIPTION
This fixes the unintended behavior of the plugin erroring out if it sees an unrecognized metric name in the list of metrics returned by AWS.

Fix is to add a new option to enable this erroring out behavior, but default to it off.

Operators using this plugin, will seldom want the error to happen unless they are debugging behavior associated with missing metrics.

People developing presets, or preset CI tests, may want the error condition to happen to ensure coverage as AWS adds new metrics over time.